### PR TITLE
Run checks

### DIFF
--- a/.github/workflows/check2.yml
+++ b/.github/workflows/check2.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  check1:
+  check2:
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ on github checks.
 ## PR 1
 
 Fix github action workflow files location.
+
+## PR 2
+
+To see how checks look like.

--- a/check
+++ b/check
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CHECK1=true
-CHECK2=false
+CHECK2=true
 
 CHECK_NAME=CHECK${1}
 if [ "${!CHECK_NAME}" != "true" ]

--- a/check
+++ b/check
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-CHECK1=false
-CHECK2=true
+CHECK1=true
+CHECK2=false
 
 CHECK_NAME=CHECK${1}
 if [ "${!CHECK_NAME}" != "true" ]

--- a/check
+++ b/check
@@ -3,7 +3,8 @@
 CHECK1=true
 CHECK2=true
 
-if [ "$CHECK$1" != "true" ]
+CHECK_NAME=CHECK${1}
+if [ "${!CHECK_NAME}" != "true" ]
 then
     exit 1
 fi

--- a/check
+++ b/check
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CHECK1=true
+CHECK1=false
 CHECK2=true
 
 CHECK_NAME=CHECK${1}


### PR DESCRIPTION
# Testing protection rules

We have two checks defined in the project:
* https://github.com/dmitry-at-hyla/test-checks/blob/master/.github/workflows/check1.yml
* https://github.com/dmitry-at-hyla/test-checks/blob/master/.github/workflows/check2.yml

Before the protection rule is added we can see these checks on the PR page:
![image](https://user-images.githubusercontent.com/32649457/105737567-b7e56b00-5efb-11eb-906b-c1e9f2c63219.png)

Adding the protection rule (note that check1 is required):
![image](https://user-images.githubusercontent.com/32649457/105740114-7a361180-5efe-11eb-9197-7d779b67f095.png)

If required check1 is failed, only the administrator can merge the PR:
![image](https://user-images.githubusercontent.com/32649457/105740608-f7fa1d00-5efe-11eb-96da-c7e905a6b2ff.png)

If not required check2 is failed, anyone can merge the PR but the button is not highlighted:
![image](https://user-images.githubusercontent.com/32649457/105741250-b1f18900-5eff-11eb-83a5-49baf28a668f.png)

If all checks are successful but the master branch has changes unmerged back to the feature branch, only the administrator can merge the PR:
![image](https://user-images.githubusercontent.com/32649457/105742297-f2053b80-5f00-11eb-8d3c-cffd7042455f.png)
